### PR TITLE
Temper accept reject

### DIFF
--- a/experiments/run_experiments.py
+++ b/experiments/run_experiments.py
@@ -41,11 +41,11 @@ lkernel: Set L-kernel. Matching configurations above asymptoptic (i), forward_lk
 """
 
 #Number of Monte-Carlo runs
-N_MCMC_RUNS = 1
+N_MCMC_RUNS = 25
 
 # Sampler configurations
 N = 100 #Number of samples
-K = 30 #Number of iterations
+K = 15 #Number of iterations
 
 # Specify model - CHANGE THIS TO CHANGE STAN MODEL
 model_name = "arma"
@@ -208,8 +208,6 @@ def main():
         tempered_nuts_smcs.sample(
             save_samples=True,
         )
-
-        print(tempered_nuts_smcs.phi)
 
         print(f"\nFinished sampling in {tempered_nuts_smcs.run_time} seconds")
 

--- a/smcnuts/proposal/nuts.py
+++ b/smcnuts/proposal/nuts.py
@@ -62,7 +62,7 @@ class NUTSProposal:
         if self.accept_reject:
             accepted = np.array([False] * len(x_prime))
             for i in range(len(x_prime)):
-                accepted[i] = hmc_accept_reject(self.target.logpdf, x_cond[i], x_prime[i], r_cond[i], r_prime[i], rng=self.rng)
+                accepted[i] = hmc_accept_reject(self.target.logpdf, x_cond[i], x_prime[i], r_cond[i], r_prime[i], phi=phi, rng=self.rng)
             x_prime[~accepted] = x_cond[~accepted]
             r_prime[~accepted] = r_cond[~accepted]
         


### PR DESCRIPTION
The current codebase does not temper the target distribution in the accept-reject step of the NUTS proposal, which is incorrect. This PR fixes that error.